### PR TITLE
feat: add custom 404 page

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html>
+  <head>
+      <link href="/image/favicon-cyan.png" rel="icon" type="image/png" />
+      <link rel="canonical" href="https://ubq.fi/" />
+      <link rel="home" href="https://ubq.fi/" />
+      <link rel="stylesheet" type="text/css" href="//inventum.digital/code/css/nv/nv.css" />
+      <link rel="stylesheet" type="text/css" href="//inventum.digital/code/css/nv/nv-dark.css" />
+      <link rel="stylesheet" type="text/css" href="/ubq.css" />
+      <meta charset="utf-8" />
+      <meta http-equiv="X-UA-Compatible" content="IE=Edge" />
+      <meta name="apple-mobile-web-app-capable" content="yes" />
+      <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+      <meta name="author" content="Ubiquity" />
+      <meta name="description" content="Ubiquity DAO" />
+      <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover" />
+      <meta property="og:description" content="Ubiquity DAO" />
+      <meta property="og:image" content="https://ubq.fi/apple-touch-icon.png" />
+      <meta property="og:locale" content="en_US" />
+      <meta property="og:site_name" content="ubq.fi" />
+      <meta property="og:title" content="ubq.fi" />
+      <meta property="og:type" content="website" />
+      <meta property="og:url" content="https://ubq.fi/" />
+      <title>Ubiquity</title>
+      <style>
+        /* Page 404 styles */
+        #Page404 {
+          display: flex;
+          height: 100%;
+        }
+        #Page404 a {
+          text-decoration: underline;
+        }
+        #Page404 ul {
+          padding: 0;
+          margin: 0;
+        }
+        #Page404 li {
+          width: 100%;
+        }
+        #Page404 > div:nth-child(1) {
+          display: flex;
+          flex-direction: column;
+          justify-content: center;
+          padding: 16px;
+        }
+        #Page404 > div:nth-child(1) > p:nth-child(1) {
+          font-size: 2rem;
+        }
+        #Page404 > div:nth-child(2) {
+          align-items: center;
+          display: flex;
+          font-size: 4rem;
+          padding: 16px;
+        }
+      </style>
+  </head>
+  <body>
+    <div id="Page404">
+      <div>
+        <p>Oops!</p>
+        <p>We can't seem to find the page you're looking for</p>
+        <p>
+          <b>Here are some helpful links instead:</b>
+        </p>
+        <ul>
+          <li>
+            <a href="//github.com/ubiquity/ubiquity-dollar/wiki" target="_blank">Docs</a>
+          </li>
+          <li>
+            <a href="//dao.ubq.fi/faq" target="_blank">FAQ</a>
+          </li>
+          <li>
+            <a href="//github.com/ubiquity/ubiquity-dollar" target="_blank">Github</a>
+          </li>
+          <li>
+            <a href="//discord.gg/SjymJ5maJ4" target="_blank">Discord</a>
+          </li>
+          <li>
+            <a href="//t.me/ubiquitydao" target="_blank">Telegram</a>
+          </li>
+          <li>
+            <a href="//twitter.com/UbiquityDAO" target="_blank">Twitter</a>
+          </li>
+        </ul>
+      </div>
+      <div>
+        404
+      </div>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
PR for https://github.com/ubiquity/ubiquity-dollar/issues/96

@pavlovcik 
Here a custom 404 page html is added. Redirect to this 404 page should be written somewhere in server settings. You can show me where I can find server configs or do it yourself.

<img width="1440" alt="Screenshot 2022-11-09 at 11 26 13" src="https://user-images.githubusercontent.com/6339689/200777995-2a22c10f-f527-44eb-9783-b233eaf841fa.png">
