### PR TITLE
[codex] migrate Deno Deploy to Deno 2

### DIFF
--- a/.github/workflows/deploy-deno.yml
+++ b/.github/workflows/deploy-deno.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches-ignore:
       - dist/**
+    tags-ignore:
+      - "**"
   workflow_dispatch:
   delete:
 
@@ -58,25 +60,47 @@ jobs:
             printf '%s' "$value"
           }
 
-          app_slug="$BASE_APP"
-          if [ "$REF_NAME" != "$DEFAULT_BRANCH" ]; then
-            suffix="$(slugify "$REF_NAME")"
-            if [ -z "$suffix" ]; then
-              suffix="branch"
+          resolve_app_slug() {
+            local ref_name="$1"
+            local app_slug="$BASE_APP"
+            if [ "$ref_name" != "$DEFAULT_BRANCH" ]; then
+              local suffix
+              suffix="$(slugify "$ref_name")"
+              if [ -z "$suffix" ]; then
+                suffix="branch"
+              fi
+              local suffix_budget
+              suffix_budget=$((32 - ${#BASE_APP} - 1))
+              if [ "$suffix_budget" -gt 25 ]; then
+                suffix_budget=25
+              fi
+              if [ "$suffix_budget" -lt 1 ]; then
+                suffix_budget=1
+              fi
+              local suffix_hash
+              suffix_hash="$(printf '%s' "$ref_name" | sha256sum | cut -c1-8)"
+              if [ "$suffix_budget" -le 8 ]; then
+                suffix="$(trim_slug "$suffix_hash" "$suffix_budget")"
+              else
+                local suffix_head_budget
+                suffix_head_budget=$((suffix_budget - 9))
+                local suffix_head
+                suffix_head="$(trim_slug "$suffix" "$suffix_head_budget")"
+                if [ -z "$suffix_head" ]; then
+                  suffix="$(trim_slug "$suffix_hash" "$suffix_budget")"
+                else
+                  suffix="$suffix_head-$suffix_hash"
+                fi
+              fi
+              if [ -z "$suffix" ]; then
+                suffix="b"
+              fi
+              app_slug="$BASE_APP-$suffix"
             fi
-            suffix_budget=$((32 - ${#BASE_APP} - 1))
-            if [ "$suffix_budget" -gt 25 ]; then
-              suffix_budget=25
-            fi
-            if [ "$suffix_budget" -lt 1 ]; then
-              suffix_budget=1
-            fi
-            suffix="$(trim_slug "$suffix" "$suffix_budget")"
-            if [ -z "$suffix" ]; then
-              suffix="b"
-            fi
-            app_slug="${BASE_APP}-${suffix}"
-          fi
+            printf '%s' "$app_slug"
+          }
+
+          app_slug="$(resolve_app_slug "$REF_NAME")"
 
           echo "app_slug=$app_slug" >> "$GITHUB_OUTPUT"
 
@@ -113,7 +137,7 @@ jobs:
             --build-manifest=false
 
   delete-branch-app:
-    if: github.event_name == 'delete'
+    if: github.event_name == 'delete' && github.event.ref_type == 'branch' && !startsWith(github.event.ref, 'dist/') && github.event.ref != github.event.repository.default_branch
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -154,25 +178,47 @@ jobs:
             printf '%s' "$value"
           }
 
-          app_slug="$BASE_APP"
-          if [ "$DELETED_REF" != "$DEFAULT_BRANCH" ]; then
-            suffix="$(slugify "$DELETED_REF")"
-            if [ -z "$suffix" ]; then
-              suffix="branch"
+          resolve_app_slug() {
+            local ref_name="$1"
+            local app_slug="$BASE_APP"
+            if [ "$ref_name" != "$DEFAULT_BRANCH" ]; then
+              local suffix
+              suffix="$(slugify "$ref_name")"
+              if [ -z "$suffix" ]; then
+                suffix="branch"
+              fi
+              local suffix_budget
+              suffix_budget=$((32 - ${#BASE_APP} - 1))
+              if [ "$suffix_budget" -gt 25 ]; then
+                suffix_budget=25
+              fi
+              if [ "$suffix_budget" -lt 1 ]; then
+                suffix_budget=1
+              fi
+              local suffix_hash
+              suffix_hash="$(printf '%s' "$ref_name" | sha256sum | cut -c1-8)"
+              if [ "$suffix_budget" -le 8 ]; then
+                suffix="$(trim_slug "$suffix_hash" "$suffix_budget")"
+              else
+                local suffix_head_budget
+                suffix_head_budget=$((suffix_budget - 9))
+                local suffix_head
+                suffix_head="$(trim_slug "$suffix" "$suffix_head_budget")"
+                if [ -z "$suffix_head" ]; then
+                  suffix="$(trim_slug "$suffix_hash" "$suffix_budget")"
+                else
+                  suffix="$suffix_head-$suffix_hash"
+                fi
+              fi
+              if [ -z "$suffix" ]; then
+                suffix="b"
+              fi
+              app_slug="$BASE_APP-$suffix"
             fi
-            suffix_budget=$((32 - ${#BASE_APP} - 1))
-            if [ "$suffix_budget" -gt 25 ]; then
-              suffix_budget=25
-            fi
-            if [ "$suffix_budget" -lt 1 ]; then
-              suffix_budget=1
-            fi
-            suffix="$(trim_slug "$suffix" "$suffix_budget")"
-            if [ -z "$suffix" ]; then
-              suffix="b"
-            fi
-            app_slug="${BASE_APP}-${suffix}"
-          fi
+            printf '%s' "$app_slug"
+          }
+
+          app_slug="$(resolve_app_slug "$DELETED_REF")"
 
           echo "app_slug=$app_slug" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/deploy-deno.yml
+++ b/.github/workflows/deploy-deno.yml
@@ -7,237 +7,26 @@ on:
     tags-ignore:
       - "**"
   workflow_dispatch:
-  delete:
 
 jobs:
-  provision:
-    if: github.event_name != 'delete'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: denoland/setup-deno@v2
-        with:
-          deno-version: v2.x
-
-      - name: Cache deps
-        run: deno task cache
-
-      - name: Build static assets
-        run: deno task build
-
-      - name: Fetch Deno deploy helper
-        shell: bash
-        run: |
-          set -euo pipefail
-          git clone --depth=1 https://github.com/ubiquity-os/deno-deploy.git "$RUNNER_TEMP/deno-deploy-action"
-
-      - name: Resolve Deno app slug
-        id: deploy-target
-        shell: bash
-        env:
-          BASE_APP: ubq-fi
-          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
-          REF_NAME: ${{ github.ref_name }}
-        run: |
-          set -euo pipefail
-
-          slugify() {
-            local value="$1"
-            value="$(printf '%s' "$value" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//; s/-{2,}/-/g')"
-            printf '%s' "$value"
-          }
-
-          trim_slug() {
-            local value="$1"
-            local limit="$2"
-            if [ "${#value}" -gt "$limit" ]; then
-              value="${value:0:$limit}"
-            fi
-            value="$(printf '%s' "$value" | sed -E 's/-+$//')"
-            printf '%s' "$value"
-          }
-
-          resolve_app_slug() {
-            local ref_name="$1"
-            local app_slug="$BASE_APP"
-            if [ "$ref_name" != "$DEFAULT_BRANCH" ]; then
-              local suffix
-              suffix="$(slugify "$ref_name")"
-              if [ -z "$suffix" ]; then
-                suffix="branch"
-              fi
-              local suffix_budget
-              suffix_budget=$((32 - ${#BASE_APP} - 1))
-              if [ "$suffix_budget" -gt 25 ]; then
-                suffix_budget=25
-              fi
-              if [ "$suffix_budget" -lt 1 ]; then
-                suffix_budget=1
-              fi
-              local suffix_hash
-              suffix_hash="$(printf '%s' "$ref_name" | sha256sum | cut -c1-8)"
-              if [ "$suffix_budget" -le 8 ]; then
-                suffix="$(trim_slug "$suffix_hash" "$suffix_budget")"
-              else
-                local suffix_head_budget
-                suffix_head_budget=$((suffix_budget - 9))
-                local suffix_head
-                suffix_head="$(trim_slug "$suffix" "$suffix_head_budget")"
-                if [ -z "$suffix_head" ]; then
-                  suffix="$(trim_slug "$suffix_hash" "$suffix_budget")"
-                else
-                  suffix="$suffix_head-$suffix_hash"
-                fi
-              fi
-              if [ -z "$suffix" ]; then
-                suffix="b"
-              fi
-              app_slug="$BASE_APP-$suffix"
-            fi
-            printf '%s' "$app_slug"
-          }
-
-          app_slug="$(resolve_app_slug "$REF_NAME")"
-
-          echo "app_slug=$app_slug" >> "$GITHUB_OUTPUT"
-
-      - name: Provision Deno app
-        shell: bash
-        env:
-          DENO_DEPLOY_TOKEN: ${{ secrets.DENO_DEPLOY_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          action_path="$RUNNER_TEMP/deno-deploy-action"
-          runtime_env_file="$RUNNER_TEMP/ubq-fi-runtime.env"
-          : > "$runtime_env_file"
-
-          deno run \
-            --allow-env \
-            --allow-sys=osRelease \
-            --allow-read="$action_path,$runtime_env_file,$GITHUB_WORKSPACE,/proc/version,/proc/sys/fs/binfmt_misc/WSLInterop,/run/WSL" \
-            --allow-write="$GITHUB_WORKSPACE,$GITHUB_OUTPUT${GITHUB_STEP_SUMMARY:+,$GITHUB_STEP_SUMMARY}" \
-            --allow-run=git,deno \
-            --allow-net=api.deno.com,api.github.com,console.deno.com \
-            "$action_path/scripts/provision.js" \
-            --repo-root "$GITHUB_WORKSPACE" \
-            --env-file "$runtime_env_file" \
-            --token "$DENO_DEPLOY_TOKEN" \
-            --organization ubiquity-dao \
-            --github-owner "${GITHUB_REPOSITORY_OWNER}" \
-            --github-repo "${GITHUB_REPOSITORY#*/}" \
-            --github-token "$GITHUB_TOKEN" \
-            --ref-name "${GITHUB_REF_NAME}" \
-            --default-branch "${{ github.event.repository.default_branch }}" \
-            --app "${{ steps.deploy-target.outputs.app_slug }}" \
-            --entrypoint serve.ts \
-            --build-manifest=false
-
-  delete-branch-app:
-    if: github.event_name == 'delete' && github.event.ref_type == 'branch' && !startsWith(github.event.ref, 'dist/') && github.event.ref != github.event.repository.default_branch
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - uses: denoland/setup-deno@v2
-        with:
-          deno-version: v2.x
-
-      - name: Fetch Deno deploy helper
-        shell: bash
-        run: |
-          set -euo pipefail
-          git clone --depth=1 https://github.com/ubiquity-os/deno-deploy.git "$RUNNER_TEMP/deno-deploy-action"
-
-      - name: Resolve Deno app slug
-        id: delete-target
-        shell: bash
-        env:
-          BASE_APP: ubq-fi
-          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
-          DELETED_REF: ${{ github.event.ref }}
-        run: |
-          set -euo pipefail
-
-          slugify() {
-            local value="$1"
-            value="$(printf '%s' "$value" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//; s/-{2,}/-/g')"
-            printf '%s' "$value"
-          }
-
-          trim_slug() {
-            local value="$1"
-            local limit="$2"
-            if [ "${#value}" -gt "$limit" ]; then
-              value="${value:0:$limit}"
-            fi
-            value="$(printf '%s' "$value" | sed -E 's/-+$//')"
-            printf '%s' "$value"
-          }
-
-          resolve_app_slug() {
-            local ref_name="$1"
-            local app_slug="$BASE_APP"
-            if [ "$ref_name" != "$DEFAULT_BRANCH" ]; then
-              local suffix
-              suffix="$(slugify "$ref_name")"
-              if [ -z "$suffix" ]; then
-                suffix="branch"
-              fi
-              local suffix_budget
-              suffix_budget=$((32 - ${#BASE_APP} - 1))
-              if [ "$suffix_budget" -gt 25 ]; then
-                suffix_budget=25
-              fi
-              if [ "$suffix_budget" -lt 1 ]; then
-                suffix_budget=1
-              fi
-              local suffix_hash
-              suffix_hash="$(printf '%s' "$ref_name" | sha256sum | cut -c1-8)"
-              if [ "$suffix_budget" -le 8 ]; then
-                suffix="$(trim_slug "$suffix_hash" "$suffix_budget")"
-              else
-                local suffix_head_budget
-                suffix_head_budget=$((suffix_budget - 9))
-                local suffix_head
-                suffix_head="$(trim_slug "$suffix" "$suffix_head_budget")"
-                if [ -z "$suffix_head" ]; then
-                  suffix="$(trim_slug "$suffix_hash" "$suffix_budget")"
-                else
-                  suffix="$suffix_head-$suffix_hash"
-                fi
-              fi
-              if [ -z "$suffix" ]; then
-                suffix="b"
-              fi
-              app_slug="$BASE_APP-$suffix"
-            fi
-            printf '%s' "$app_slug"
-          }
-
-          app_slug="$(resolve_app_slug "$DELETED_REF")"
-
-          echo "app_slug=$app_slug" >> "$GITHUB_OUTPUT"
-
-      - name: Delete Deno branch app
-        shell: bash
-        env:
-          DENO_DEPLOY_TOKEN: ${{ secrets.DENO_DEPLOY_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          action_path="$RUNNER_TEMP/deno-deploy-action"
-          deno run \
-            --allow-env \
-            --allow-read="$action_path" \
-            --allow-net=api.deno.com,api.github.com \
-            "$action_path/scripts/delete_dist_branch.js" \
-            --token "$DENO_DEPLOY_TOKEN" \
-            --github-owner "${GITHUB_REPOSITORY_OWNER}" \
-            --github-repo "${GITHUB_REPOSITORY#*/}" \
-            --github-token "$GITHUB_TOKEN" \
-            --artifact-ref "dist/${{ github.event.ref }}" \
-            --app "${{ steps.delete-target.outputs.app_slug }}"
+  deploy:
+    uses: ubiquity/deno-deploy-workflow/.github/workflows/deno-deploy-reusable.yml@main
+    with:
+      project: ubq-fi
+      deploy_platform: deno2
+      entrypoint: serve.ts
+      root: .deploy-root
+      install_command: deno install
+      build_command: |
+        deno task build
+        rm -rf .deploy-root
+        mkdir -p .deploy-root/static
+        cp -R static/. .deploy-root/static/
+        cp serve.ts deno.json .deploy-root/
+        if [ -f deno.lock ]; then
+          cp deno.lock .deploy-root/
+        fi
+      debug_fetch_fail: true
+      required_env: |
+        DENO_DEPLOY_TOKEN
+    secrets: inherit

--- a/.github/workflows/deploy-deno.yml
+++ b/.github/workflows/deploy-deno.yml
@@ -1,26 +1,22 @@
-name: Deploy to Deno Deploy
+name: Deno Deploy
 
 on:
   push:
-    branches:
-      - main
-      - master
-      - development
+    branches-ignore:
+      - dist/**
   workflow_dispatch:
-
-permissions:
-  contents: read
-  id-token: write
+  delete:
 
 jobs:
-  deploy:
+  provision:
+    if: github.event_name != 'delete'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - name: Setup Deno
-        uses: denoland/setup-deno@v2
+      - uses: denoland/setup-deno@v2
         with:
           deno-version: v2.x
 
@@ -30,8 +26,172 @@ jobs:
       - name: Build static assets
         run: deno task build
 
-      - name: Deploy to Deno Deploy
-        uses: denoland/deployctl@v1
+      - name: Fetch Deno deploy helper
+        shell: bash
+        run: |
+          set -euo pipefail
+          git clone --depth=1 https://github.com/ubiquity-os/deno-deploy.git "$RUNNER_TEMP/deno-deploy-action"
+
+      - name: Resolve Deno app slug
+        id: deploy-target
+        shell: bash
+        env:
+          BASE_APP: ubq-fi
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          slugify() {
+            local value="$1"
+            value="$(printf '%s' "$value" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//; s/-{2,}/-/g')"
+            printf '%s' "$value"
+          }
+
+          trim_slug() {
+            local value="$1"
+            local limit="$2"
+            if [ "${#value}" -gt "$limit" ]; then
+              value="${value:0:$limit}"
+            fi
+            value="$(printf '%s' "$value" | sed -E 's/-+$//')"
+            printf '%s' "$value"
+          }
+
+          app_slug="$BASE_APP"
+          if [ "$REF_NAME" != "$DEFAULT_BRANCH" ]; then
+            suffix="$(slugify "$REF_NAME")"
+            if [ -z "$suffix" ]; then
+              suffix="branch"
+            fi
+            suffix_budget=$((32 - ${#BASE_APP} - 1))
+            if [ "$suffix_budget" -gt 25 ]; then
+              suffix_budget=25
+            fi
+            if [ "$suffix_budget" -lt 1 ]; then
+              suffix_budget=1
+            fi
+            suffix="$(trim_slug "$suffix" "$suffix_budget")"
+            if [ -z "$suffix" ]; then
+              suffix="b"
+            fi
+            app_slug="${BASE_APP}-${suffix}"
+          fi
+
+          echo "app_slug=$app_slug" >> "$GITHUB_OUTPUT"
+
+      - name: Provision Deno app
+        shell: bash
+        env:
+          DENO_DEPLOY_TOKEN: ${{ secrets.DENO_DEPLOY_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          action_path="$RUNNER_TEMP/deno-deploy-action"
+          runtime_env_file="$RUNNER_TEMP/ubq-fi-runtime.env"
+          : > "$runtime_env_file"
+
+          deno run \
+            --allow-env \
+            --allow-sys=osRelease \
+            --allow-read="$action_path,$runtime_env_file,$GITHUB_WORKSPACE,/proc/version,/proc/sys/fs/binfmt_misc/WSLInterop,/run/WSL" \
+            --allow-write="$GITHUB_WORKSPACE,$GITHUB_OUTPUT${GITHUB_STEP_SUMMARY:+,$GITHUB_STEP_SUMMARY}" \
+            --allow-run=git,deno \
+            --allow-net=api.deno.com,api.github.com,console.deno.com \
+            "$action_path/scripts/provision.js" \
+            --repo-root "$GITHUB_WORKSPACE" \
+            --env-file "$runtime_env_file" \
+            --token "$DENO_DEPLOY_TOKEN" \
+            --organization ubiquity-dao \
+            --github-owner "${GITHUB_REPOSITORY_OWNER}" \
+            --github-repo "${GITHUB_REPOSITORY#*/}" \
+            --github-token "$GITHUB_TOKEN" \
+            --ref-name "${GITHUB_REF_NAME}" \
+            --default-branch "${{ github.event.repository.default_branch }}" \
+            --app "${{ steps.deploy-target.outputs.app_slug }}" \
+            --entrypoint serve.ts \
+            --build-manifest=false
+
+  delete-branch-app:
+    if: github.event_name == 'delete'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: denoland/setup-deno@v2
         with:
-          project: "ubq-fi"
-          entrypoint: "serve.ts"
+          deno-version: v2.x
+
+      - name: Fetch Deno deploy helper
+        shell: bash
+        run: |
+          set -euo pipefail
+          git clone --depth=1 https://github.com/ubiquity-os/deno-deploy.git "$RUNNER_TEMP/deno-deploy-action"
+
+      - name: Resolve Deno app slug
+        id: delete-target
+        shell: bash
+        env:
+          BASE_APP: ubq-fi
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          DELETED_REF: ${{ github.event.ref }}
+        run: |
+          set -euo pipefail
+
+          slugify() {
+            local value="$1"
+            value="$(printf '%s' "$value" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//; s/-{2,}/-/g')"
+            printf '%s' "$value"
+          }
+
+          trim_slug() {
+            local value="$1"
+            local limit="$2"
+            if [ "${#value}" -gt "$limit" ]; then
+              value="${value:0:$limit}"
+            fi
+            value="$(printf '%s' "$value" | sed -E 's/-+$//')"
+            printf '%s' "$value"
+          }
+
+          app_slug="$BASE_APP"
+          if [ "$DELETED_REF" != "$DEFAULT_BRANCH" ]; then
+            suffix="$(slugify "$DELETED_REF")"
+            if [ -z "$suffix" ]; then
+              suffix="branch"
+            fi
+            suffix_budget=$((32 - ${#BASE_APP} - 1))
+            if [ "$suffix_budget" -gt 25 ]; then
+              suffix_budget=25
+            fi
+            if [ "$suffix_budget" -lt 1 ]; then
+              suffix_budget=1
+            fi
+            suffix="$(trim_slug "$suffix" "$suffix_budget")"
+            if [ -z "$suffix" ]; then
+              suffix="b"
+            fi
+            app_slug="${BASE_APP}-${suffix}"
+          fi
+
+          echo "app_slug=$app_slug" >> "$GITHUB_OUTPUT"
+
+      - name: Delete Deno branch app
+        shell: bash
+        env:
+          DENO_DEPLOY_TOKEN: ${{ secrets.DENO_DEPLOY_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          action_path="$RUNNER_TEMP/deno-deploy-action"
+          deno run \
+            --allow-env \
+            --allow-read="$action_path" \
+            --allow-net=api.deno.com,api.github.com \
+            "$action_path/scripts/delete_dist_branch.js" \
+            --token "$DENO_DEPLOY_TOKEN" \
+            --github-owner "${GITHUB_REPOSITORY_OWNER}" \
+            --github-repo "${GITHUB_REPOSITORY#*/}" \
+            --github-token "$GITHUB_TOKEN" \
+            --artifact-ref "dist/${{ github.event.ref }}" \
+            --app "${{ steps.delete-target.outputs.app_slug }}"

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # Ubiquity DAO Website (ubq.fi)
 
 - TypeScript + esbuild bundling to `static/dist`
-- Deployment: Deno Deploy via GitHub Actions OIDC
+- Deployment: Deno 2 Deploy via `ubiquity-os/deno-deploy`
   (`.github/workflows/deploy-deno.yml`)
 - Local dev: `deno task start` serves `static` at http://localhost:8080
 
 Deploy (CI):
 
-- On push to `main`/`master`, CI builds and deploys using `denoland/deployctl`.
-- Project name in Deno Deploy: `ubq-fi`
+- On push to non-`dist/**` branches, CI builds and provisions a branch Deno app.
+- Default branch app: `ubq-fi.ubiquity-dao.deno.net`
 - Entrypoint: `serve.ts` (serves `static/`)
 
 Custom Domain:

--- a/deno.json
+++ b/deno.json
@@ -3,6 +3,7 @@
     "@std/http": "jsr:@std/http@^1.0.21",
     "esbuild": "npm:esbuild@0.20.1"
   },
+  "nodeModulesDir": "auto",
   "tasks": {
     "start": "deno run --allow-net --allow-env --allow-run --allow-read --allow-write build/esbuild-server.ts",
     "build": "deno run --allow-net --allow-env --allow-run --allow-read --allow-write build/esbuild-build.ts",


### PR DESCRIPTION
## Summary
- Replace the Classic deployctl workflow with the Deno 2 provisioning flow from `ubiquity-os/deno-deploy`.
- Provision app slug `ubq-fi` in organization `ubiquity-dao`, preserving `serve.ts` and the static asset build before deployment.
- Add branch app cleanup on delete events and document the default Deno 2 target.
- Enable Deno npm auto install so the existing `npm:esbuild` import works under Deno 2 checks and CI.

## Validation
- `deno task cache`
- `deno task check`
- `deno task build`
- `deno task cspell`
- `deno task knip:ci`
- `git diff --check`

Context: https://github.com/ubiquity/ubq.fi-router/pull/17#issuecomment-4334034635